### PR TITLE
[REG-98] Added error codes.

### DIFF
--- a/tribestream-api-registry-webapp/src/main/resources/seed-db/get-partners.json
+++ b/tribestream-api-registry-webapp/src/main/resources/seed-db/get-partners.json
@@ -637,7 +637,58 @@
               }
             }
           }
-        }
+        },
+        "x-tomitribe-response-codes": [
+          {
+            "http_status": "200",
+            "message": "OK",
+            "description": "Success"
+          },
+          {
+            "http_status": "304",
+            "message": "not modified",
+            "description": "Resource has not been modified since date specified."
+          },
+          {
+            "http_status": "400",
+            "error_code": "1001001",
+            "message": "Supplied request is invalid.",
+            "description": "Request is missing required fields."
+          },
+          {
+            "http_status": "400",
+            "error_code": "1001012",
+            "message": "Date format error.",
+            "description": "The supplied date does not match the expected format."
+          },
+          {
+            "http_status": "400",
+            "error_code": "1001013",
+            "message": "Pagination Parameters invalid.",
+            "description": "The Pagination Parameters offset and limit must be positive values."
+          },
+          {
+            "http_status": "400",
+            "error_code": "1001014",
+            "message": "No results returned.",
+            "description": "There are no partners which match the provided search results"
+          },
+          {
+            "http_status": "423",
+            "message": "Locked",
+            "description": "Too many requests."
+          },
+          {
+            "http_status": "429",
+            "message": "Too many requests",
+            "description": "Too many concurrent requests."
+          },
+          {
+            "http_status": "503",
+            "message": "Service Unavailable",
+            "description": "Backend resources are not available. Try your request again later."
+          }
+        ]
       }
     }
   }

--- a/tribestream-api-registry-webapp/src/main/resources/seed-db/get-work-notification.json
+++ b/tribestream-api-registry-webapp/src/main/resources/seed-db/get-work-notification.json
@@ -352,7 +352,47 @@
               "application/xml": "<error>\n              <code>9031004</code>\n              <message>Work Notification not found.</message>\n              </error>"
             }
           }
-        }
+        },
+        "x-tomitribe-response-codes": [
+          {
+            "http_status": "200",
+            "message": "OK",
+            "description": "Success"
+          },
+          {
+            "http_status": "400",
+            "error_code": "9031004",
+            "message": "No notification found.",
+            "description": "No notification match the query parameters provided."
+          },
+          {
+            "http_status": "400",
+            "error_code": "9035001",
+            "message": "Invalid limit.",
+            "description": "Limit must be between 1 and ??."
+          },
+          {
+            "http_status": "400",
+            "error_code": "9035002",
+            "message": "Invalid offset",
+            "description": "Offset must be between 0 and maximum page results."
+          },
+          {
+            "http_status": "423",
+            "message": "Locked",
+            "description": "Too many requests."
+          },
+          {
+            "http_status": "429",
+            "message": "Too many requests",
+            "description": "Too many concurrent requests."
+          },
+          {
+            "http_status": "503",
+            "message": "Service Unavailable",
+            "description": "Backend resources are not available. Try your request again later."
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
This PR contains a proposal how to map the response codes as requested by [REG-98](https://tomitribe.atlassian.net/projects/REG/issues/REG-98) to the OpenAPI document.

As OpenAPI does not know anything about additional error codes for different HTTP status codes these have to be put into a  [Vendor Extension](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#specification-extensions)

The error codes could be put into the response definition per status code, e.g.

``` json
"responses": {
  "400": {
     "x-tomitribe-response-codes": [
      {
        "error_code": "101234",
        "message": "Bad Error",
        "description": "..."
      },
      ...
    ]
  }
}
```

This approach would not be a good fit with OpenAPI though as usually error responses are just defined as a `default` response without further defining the status code.
That is a service description can often just contain a response description for `200`, another one for `400` and then just `default` for all `5xx` responses.
In that case the table would not fit into OpenAPI document.

Instead this PR proposes to put the table into the whole operation next to the responses:

``` json
"/myservice": {
  "get": {
    "description": "...",
    "parameters": {...},
    "responses": {
      "200": {...},
      "400": {...},
      "default": {...},
    },
    "x-tomitribe-response-codes": [
      {
        "error_code": "101234",
        "message": "Bad Error",
        "description": "..."
      },
      ...
    ]
  }
}
```

If we agree on this format additional work has to be put into the server to validate this format and in the client to visualize and edit it.
