### PR TITLE
Adds response examples back to the endpoint details page

### DIFF
--- a/tribestream-api-registry-webapp/src/main/static/assets/templates/app_endpoints_details_response_request.jade
+++ b/tribestream-api-registry-webapp/src/main/static/assets/templates/app_endpoints_details_response_request.jade
@@ -49,5 +49,12 @@ div
             div(x-ng-click="removeErrorCode(val);")
               i.fa.fa-trash-o
   .samples
+    h2 #[span Request Headers]
+    div(data-tribe-editable-block, data-content="endpoint.samples.requestHeaders")
+    h2 #[span Response Parameters]
+    div(data-tribe-editable-block, data-content="endpoint.samples.responseParameters")
+
     h2 #[span Response Body]
-    div(data-tribe-editable-md, data-content="endpoint.samples.responseBody")
+    div(data-tribe-editable-block, data-content="endpoint.samples.sampleXmlResponse")
+    h2 #[span Response Body Sample Error]
+    div(data-tribe-editable-block, data-content="endpoint.samples.defaultSampleXmlResponse")


### PR DESCRIPTION
This PR adds example response bodies back to the endpoint details.
For now the "Response Body" field will contain the response body example of the lowest 2xx response, i.e. usually 200 or 201.
The field "Response Body Sample Error" will show the XML example for the "default" response.

![bildschirmfoto 2016-08-24 um 17 13 14](https://cloud.githubusercontent.com/assets/1163662/17936213/54340a84-6a1e-11e6-87ac-9d3bbbd60b14.png)
