### PR TITLE
[REG-226] Fix persisting expected values of parameters on endpoint details page.

### DIFF
--- a/tribestream-api-registry-webapp/src/main/static/assets/scripts/endpoints_details.ts
+++ b/tribestream-api-registry-webapp/src/main/static/assets/scripts/endpoints_details.ts
@@ -424,7 +424,7 @@ angular.module('tribe-endpoints-details', [
                             }
                             $scope.endpoint.operation['x-tribestream-api-registry']['expected-values'] = _.without(
                                 $scope.endpoint.operation['x-tribestream-api-registry']['expected-values'],
-                                code
+                                value
                             );
                         });
                     });

--- a/tribestream-api-registry-webapp/src/main/static/assets/templates/app_endpoints_details_response_request.jade
+++ b/tribestream-api-registry-webapp/src/main/static/assets/templates/app_endpoints_details_response_request.jade
@@ -3,7 +3,7 @@ div
     h2 Expected values
       div(x-ng-click="addExpectedValue();")
         i.fa.fa-plus
-    table(x-ng-if="endpoint.operation['x-tribestream-api-registry'] && endpoint.operation['x-tribestream-api-registry']['expected-values'] && endpoint.operation['x-tribestream-api-registry']['expected-values'].length")
+    table(x-ng-if="endpoint.operation['x-tribestream-api-registry']['expected-values'].length")
       thead
         tr
           th Attribute


### PR DESCRIPTION
Persisting Expected Values on the endpoint details page did not work because the properties were set directly on the JS object representing the EndpointWrapper instead of setting them on the vendor extension of the endpoint.

That is Expected Values were directly set on EndpointWrapper (Not even on the Swagger Operation object!).

This PR fixes this by setting the Expected Values on EndpointWrapper.operation.x-tribestream-api-registry.expected-values.
