### PR TITLE
REG-229 initial testing stack setup

### DIFF
--- a/tribestream-api-registry-webapp/pom.xml
+++ b/tribestream-api-registry-webapp/pom.xml
@@ -17,7 +17,11 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+          http://maven.apache.org/POM/4.0.0
+          http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -31,6 +35,8 @@
   <packaging>war</packaging>
 
   <properties>
+    <arquillian-phantom-binary.version>2.1.1</arquillian-phantom-binary.version>
+    <selenium.version>2.53.0</selenium.version>
     <h2.version>1.4.192</h2.version>
   </properties>
 
@@ -177,6 +183,75 @@
       <groupId>org.apache.tomee</groupId>
       <artifactId>tomee-embedded</artifactId>
       <version>${version.tomee}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.codeborne</groupId>
+      <artifactId>phantomjsdriver</artifactId>
+      <version>1.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-phantom-driver</artifactId>
+      <version>1.2.1.Final</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-remote-driver</artifactId>
+      <version>${selenium.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-java</artifactId>
+      <version>${selenium.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-support</artifactId>
+      <version>${selenium.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-phantom-binary</artifactId>
+      <classifier>macosx</classifier>
+      <version>${arquillian-phantom-binary.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-phantom-binary</artifactId>
+      <classifier>linux-64</classifier>
+      <version>${arquillian-phantom-binary.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-phantom-binary</artifactId>
+      <classifier>windows</classifier>
+      <version>${arquillian-phantom-binary.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomee</groupId>
+      <artifactId>ziplock</artifactId>
+      <version>${version.tomee}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.jtidy</groupId>
+      <artifactId>jtidy</artifactId>
+      <version>r938</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tribestream-api-registry-webapp/src/main/webapp/index.jsp
+++ b/tribestream-api-registry-webapp/src/main/webapp/index.jsp
@@ -1,3 +1,4 @@
+<%@ page session="false" %>
 <!DOCTYPE html>
 <%
     boolean testing = false;

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/ApplicationHistoryResourceTest.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/ApplicationHistoryResourceTest.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.tomitribe.tribestream.registryng.cdi.Tribe;
+import org.tomitribe.tribestream.registryng.test.Registry;
 import org.tomitribe.tribestream.registryng.domain.ApplicationWrapper;
 import org.tomitribe.tribestream.registryng.domain.HistoryItem;
 import org.tomitribe.tribestream.registryng.domain.SearchPage;
@@ -46,7 +47,7 @@ import static javax.ws.rs.client.Entity.entity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.tomitribe.tribestream.registryng.resources.Registry.TESTUSER;
+import static org.tomitribe.tribestream.registryng.test.Registry.TESTUSER;
 
 @RunWith(TomEEEmbeddedSingleRunner.class)
 public class ApplicationHistoryResourceTest {

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/ApplicationResourceTest.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/ApplicationResourceTest.java
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.tomitribe.tribestream.registryng.cdi.Tribe;
+import org.tomitribe.tribestream.registryng.test.Registry;
 import org.tomitribe.tribestream.registryng.domain.ApplicationWrapper;
 import org.tomitribe.tribestream.registryng.domain.EndpointWrapper;
 import org.tomitribe.tribestream.registryng.domain.SearchPage;

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/EndpointHistoryResourceTest.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/EndpointHistoryResourceTest.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.tomitribe.tribestream.registryng.cdi.Tribe;
+import org.tomitribe.tribestream.registryng.test.Registry;
 import org.tomitribe.tribestream.registryng.domain.EndpointWrapper;
 import org.tomitribe.tribestream.registryng.domain.HistoryItem;
 import org.tomitribe.tribestream.registryng.domain.SearchPage;
@@ -45,7 +46,7 @@ import static javax.ws.rs.client.Entity.entity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.tomitribe.tribestream.registryng.resources.Registry.TESTUSER;
+import static org.tomitribe.tribestream.registryng.test.Registry.TESTUSER;
 
 @RunWith(TomEEEmbeddedSingleRunner.class)
 public class EndpointHistoryResourceTest {

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/EndpointResourceTest.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/EndpointResourceTest.java
@@ -26,6 +26,7 @@ import org.apache.tomee.embedded.junit.TomEEEmbeddedSingleRunner;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.tomitribe.tribestream.registryng.test.Registry;
 import org.tomitribe.tribestream.registryng.domain.ApplicationWrapper;
 import org.tomitribe.tribestream.registryng.domain.EndpointWrapper;
 import org.tomitribe.tribestream.registryng.domain.SearchPage;

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/HumanReadableResourceTest.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/resources/HumanReadableResourceTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.tomitribe.tribestream.registryng.domain.ApplicationWrapper;
 import org.tomitribe.tribestream.registryng.domain.EndpointWrapper;
 import org.tomitribe.tribestream.registryng.domain.TribestreamOpenAPIExtension;
+import org.tomitribe.tribestream.registryng.test.Registry;
 
 import javax.ws.rs.NotFoundException;
 import java.util.Map;

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/PrepareResources.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/PrepareResources.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.tomitribe.tribestream.registryng.test;
+
+import org.apache.openejb.loader.Files;
+import org.apache.openejb.loader.IO;
+import org.apache.tomee.embedded.junit.TomEEEmbeddedSingleRunner;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.fail;
+
+// our webapp resource build doesn't respect much docbase philosophy so let's fake one
+public class PrepareResources implements TomEEEmbeddedSingleRunner.LifecycleTask {
+    @Override
+    public Closeable beforeContainerStartup() {
+        final File out = new File("target/tests-webapp/");
+        Files.deleteOnExit(out);
+        Stream.of("target/static-resources", "src/main/webapp")
+                .forEach(s -> {
+                    try {
+                        IO.copyDirectory(new File(s), out);
+                    } catch (final IOException e) {
+                        fail(e.getMessage());
+                    }
+                });
+        return () -> {
+        };
+    }
+}

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/security/EmbeddedLoginContext.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/security/EmbeddedLoginContext.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.tomitribe.tribestream.registryng.resources.security;
+package org.tomitribe.tribestream.registryng.test.security;
 
 import org.tomitribe.tribestream.registryng.security.LoginContext;
 

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/selenium/PhantomJsLifecycle.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/selenium/PhantomJsLifecycle.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.tomitribe.tribestream.registryng.test.selenium;
+
+import org.apache.openejb.util.JarExtractor;
+import org.apache.tomee.embedded.junit.TomEEEmbeddedSingleRunner;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import static java.util.Optional.ofNullable;
+import static org.apache.ziplock.JarLocation.jarFromRegex;
+
+// small wrapper creating a phantomjs driver instance and managing its lifecycle
+// note that with 7.0.2 upgrade we will get right of the singleton and use in the Registry class:
+//
+// @TomEEEmbeddedApplicationRunner.LifecycleTask
+// private PhantomJsLifecycle.Task phantomjsLifecycle;
+//
+public class PhantomJsLifecycle {
+    public static final PhantomJsLifecycle SINGLETON = new PhantomJsLifecycle("target/Registry-phantomjs-" + System.nanoTime());
+
+    private final String work;
+    private PhantomJSDriverService service;
+    private PhantomJSDriver driver;
+
+    private PhantomJsLifecycle(final String work) {
+        this.work = work;
+    }
+
+    public PhantomJSDriver getDriver() {
+        ensureServiceExists();
+        return driver == null ? (driver = new PhantomJSDriver(service, DesiredCapabilities.chrome())) : driver;
+    }
+
+    private void ensureServiceExists() {
+        if (service != null) {
+            return;
+        }
+
+        final File phantomJs = new File(work, "phantomjs");
+        try {
+            JarExtractor.extract(jarFromRegex("arquillian-phantom-binary.*" + findClassifier() + ".jar"), phantomJs);
+        } catch (final IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        final File exec = new File(phantomJs, "bin/phantomjs" + (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win") ? ".exe" : ""));
+        if (!exec.isFile()) {
+            throw new IllegalStateException("Didn't find phantomjs executable in " + phantomJs);
+        }
+        exec.setExecutable(true); // ignore returned value for platform ignoring that
+
+        service = new PhantomJSDriverService.Builder()
+                .withLogFile(new File(work, "ghostdriver.log"))
+                .usingPhantomJSExecutable(exec)
+                .usingAnyFreePort()
+                .build();
+    }
+
+    private static String findClassifier() {
+        final String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+        if (os.contains("mac")) {
+            return "macosx";
+        }
+        if (os.contains("win")) {
+            return "windows";
+        }
+        if (os.contains("linux")) {
+            return "linux-64";
+        }
+        return ""; // fine if a single impl is there
+    }
+
+    public static class Task implements TomEEEmbeddedSingleRunner.LifecycleTask {
+        @Override
+        public Closeable beforeContainerStartup() { // allows to ensure we close it with the container automatically
+            return () -> {
+                try {
+                    ofNullable(SINGLETON.driver).ifPresent(PhantomJSDriver::close);
+                } finally {
+                    ofNullable(SINGLETON.service).ifPresent(PhantomJSDriverService::stop);
+                }
+            };
+        }
+    }
+}

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/selenium/WebAppTesting.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/test/selenium/WebAppTesting.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.tomitribe.tribestream.registryng.test.selenium;
+
+import com.google.common.base.Predicate;
+import lombok.experimental.Delegate;
+import org.apache.tomee.embedded.junit.TomEEEmbeddedSingleRunner;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.tomitribe.tribestream.registryng.test.Registry;
+import org.w3c.tidy.Tidy;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.function.Supplier;
+
+import static java.util.Optional.ofNullable;
+import static org.junit.Assert.fail;
+import static org.junit.rules.RuleChain.outerRule;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
+
+// integrates FluentLenium with our webdriver in a smooth way for end tests
+public abstract class WebAppTesting implements WebDriver, JavascriptExecutor {
+    /* needs 7.0.2 to work, workaround is to capture it in the child ATM
+    @Application
+    private Registry registry;
+     */
+
+    @Delegate
+    protected WebDriver driver;
+
+    @Delegate
+    protected JavascriptExecutor executor;
+
+    @Delegate
+    protected J8WebDriverWait waitingDriver;
+
+    @FindBy(css = "form[x-ng-submit='login()']")
+    private WebElement loginForm;
+
+    @FindBy(css = "input[x-ng-model='username']")
+    private WebElement username;
+
+    @FindBy(css = "input[x-ng-model='password']")
+    private WebElement password;
+
+    @FindBy(css = "button[type='submit']")
+    private WebElement submit;
+
+    @FindBy(className = "fa-sign-out")
+    private WebElement logout;
+
+    @Rule // dump the dom on error, will avoid some round trips
+    public final TestRule debugRule = outerRule(new TomEEEmbeddedSingleRunner.Rule(this))
+            .around(new TestRule() {
+                @Override
+                public Statement apply(final Statement base, final Description description) {
+                    return new Statement() {
+                        @Override
+                        public void evaluate() throws Throwable {
+                            final Registry registry = findRegistry();
+                            driver = registry.getWebDriver();
+                            executor = JavascriptExecutor.class.cast(driver);
+                            waitingDriver = new J8WebDriverWait(driver, Integer.getInteger("test.registry.web.wait", 60));
+
+                            driver.manage().window().maximize();
+                            driver.get(registry.root());
+                            PageFactory.initElements(driver, WebAppTesting.this);
+                            doLogin();
+                            try {
+                                base.evaluate();
+                            } catch (final Exception e) {
+                                ofNullable(driver).ifPresent(d -> {
+                                    final String source = d.getPageSource();
+
+                                    // format the output (default is all but readable)
+                                    final Tidy tidy = new Tidy();
+                                    tidy.setShowErrors(0);
+                                    tidy.setForceOutput(true);
+                                    tidy.setSmartIndent(true);
+                                    tidy.setSpaces(2);
+                                    final StringWriter formatted = new StringWriter();
+                                    tidy.parse(new StringReader(source), formatted);
+
+                                    // and dump it to let the tester inspect what he did wrong
+                                    System.out.println();
+                                    System.out.println();
+                                    System.out.println("DOM for " + description.getDisplayName());
+                                    System.out.println();
+                                    System.out.println(formatted.toString());
+                                    System.out.println();
+                                    System.out.println();
+                                });
+                                throw e;
+                            } finally {
+                                if (driver != null && needsLogin()) {
+                                    try {
+                                        logout.click();
+                                        waitingDriver.until(new Predicate<WebDriver>() {
+                                            @Override
+                                            public boolean apply(final WebDriver webDriver) {
+                                                return webDriver.getCurrentUrl().endsWith("/login");
+                                            }
+                                        });
+                                    } catch (final Exception e) {
+                                        // swallow this one and throw the other one
+                                    }
+                                }
+                            }
+                        }
+                    };
+                }
+            });
+
+    private void doLogin() {
+        if (!needsLogin()) {
+            return;
+        }
+        waitingDriver.ignoring(NoSuchElementException.class).until(visibilityOf(loginForm));
+        username.clear();
+        username.sendKeys(Registry.TESTUSER);
+        password.clear();
+        password.sendKeys(Registry.TESTPASSWORD);
+        submit.click();
+        waitingDriver.ignoring(NoSuchElementException.class).until(visibilityOf(logout));
+    }
+
+    // here to be overriden if one page needs to test the auth or that it is public
+    // if really use we can add @Public
+    protected boolean needsLogin() {
+        return true;
+    }
+
+    // see comment at the top of that class
+    private Registry findRegistry() {
+        for (final Field f : getClass().getDeclaredFields()) {
+            if (f.getType() == Registry.class) {
+                f.setAccessible(true);
+                try {
+                    return (Registry) f.get(this);
+                } catch (IllegalAccessException e) {
+                    fail(e.getMessage());
+                }
+            }
+        }
+        fail("Didn't find @Application Registry registry; in " + this);
+        throw new IllegalStateException(); // we'll not hit it but needed to make compilation happy
+    }
+
+    public static final class J8WebDriverWait extends WebDriverWait {
+        private J8WebDriverWait(WebDriver driver, long timeOutInSeconds) {
+            super(driver, timeOutInSeconds);
+        }
+
+        public void until(final Supplier<Boolean> isTrue) {
+            super.until(new Predicate<WebDriver>() {
+                @Override
+                public boolean apply(final WebDriver webDriver) {
+                    return isTrue.get();
+                }
+            });
+        }
+    }
+}

--- a/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/webapp/HomeTest.java
+++ b/tribestream-api-registry-webapp/src/test/java/org/tomitribe/tribestream/registryng/webapp/HomeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.tomitribe.tribestream.registryng.webapp;
+
+import org.apache.openejb.testing.Application;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.tomitribe.tribestream.registryng.test.Registry;
+import org.tomitribe.tribestream.registryng.test.selenium.WebAppTesting;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.openqa.selenium.By.cssSelector;
+
+public class HomeTest extends WebAppTesting {
+    @Application
+    private Registry registry;
+
+    @FindBy(css = "div[x-ng-repeat='application in applications']")
+    private List<WebElement> applications;
+
+    @Test
+    public void ensureHomeListsDefaultApps() {
+        waitingDriver.until(() -> applications.size() == 3);
+
+        final Map<String, Collection<String>> expectedApplications = new HashMap<String, Collection<String>>() {{
+            put("Swagger Petstore 1.0.0(4)", new HashSet<String>() {{
+                add("GET /pets");
+                add("GET /pets/:id");
+                add("DELETE /pets/:id");
+                add("POST /pets");
+            }});
+            put("Partners App 1.0.0(2)", new HashSet<String>() {{
+                add("GET /workNotifications/:region/:function");
+                add("GET /partners/:countryCode");
+            }});
+            put("Uber API 1.0.0(5)", new HashSet<String>() {{
+                add("GET /estimates/pricePrice Estimates");
+                add("GET /historyUser Activity");
+                add("GET /estimates/timeTime Estimates");
+                add("GET /meUser Profile");
+                add("GET /productsProduct Types");
+            }});
+        }};
+
+        applications.forEach(app -> assertEquals(
+                expectedApplications.remove(app.findElement(cssSelector("h2")).getText() /*app name + version + number of endpoints*/),
+                app.findElements(cssSelector("div[x-ng-repeat='endpoint in endpoints']")).stream().map(WebElement::getText).collect(toSet())));
+
+        // we saw all applications we expected
+        assertTrue(expectedApplications.keySet().toString(), expectedApplications.isEmpty());
+    }
+}


### PR DESCRIPTION
Basic testing stack setup with one sample (HomeTest)

Side note: the build can fail cause it requires #59 to be merged since it includes some fix on the data mutation in tests.

Also please note that this PR get rid of the JSP session for index.jsp which avoids to leak sessions we don't use anyway (noticed cause of exceptions printed after the tests)
