### PR TITLE
[not to merge] basic oauth2/basic header provider impl, still to wire to auth if needed

### DIFF
--- a/tribestream-api-registry-webapp/src/main/static/assets/scripts/_services_header_providers.ts
+++ b/tribestream-api-registry-webapp/src/main/static/assets/scripts/_services_header_providers.ts
@@ -1,0 +1,133 @@
+///<reference path="../../bower_components/DefinitelyTyped/angularjs/angular.d.ts"/>
+///<reference path="../../bower_components/DefinitelyTyped/js-base64/js-base64.d.ts"/>
+
+interface AuthenticationHeaderProvider { // TODO: move to a shared module to do basic too?
+  login(username: string, password: string): angular.IPromise<any>;
+  logout();
+  isValid(): boolean;
+  getAuthorizationHeader(): angular.IPromise<string>;
+}
+
+class BasicHeaderProvider implements AuthenticationHeaderProvider {
+  private token: string;
+
+  constructor(private $q: angular.IQService) {
+  }
+
+  login(username: string, password: string): angular.IPromise<any> {
+    this.token = 'Basic ' + Base64.encode(username + ':' + password);
+    const deferred = this.$q.defer();
+    deferred.resolve({token: this.token});
+    return deferred.promise;
+  }
+
+  logout() {
+    this.token = undefined;
+  }
+
+  isValid(): boolean {
+    return !!this.token;
+  }
+
+  getAuthorizationHeader(): angular.IPromise<string> {
+    const deferred = this.$q.defer();
+    deferred.resolve(this.token);
+    return deferred.promise;
+  }
+}
+
+class OAuth2HeaderProvider implements AuthenticationHeaderProvider {
+  private token;
+  private expiration: number;
+  private retry = 0;
+
+  constructor(private $http: angular.IHttpService,
+              private $q: angular.IQService) {
+  }
+
+  login(username: string, password: string) {
+    // client_*  are owned by the server, don't put them here
+    const start = new Date().getTime();
+    return this.$http.post(
+        'api/security/oauth2',
+        'username=' + encodeURIComponent(username) + '&password=' + encodeURIComponent(password) + '&grant_type=password',
+        {headers: {'Content-Type': 'application/x-www-form-urlencoded'}})
+      .then((response) => this.onLoad(response, start));
+  }
+
+  logout() {
+    if (!this.isLogged()) {
+      return;
+    }
+    this.token = undefined;
+  }
+
+  /**
+   * Build a promise returning the authentication header to set on the http request.
+   * Note that it automatically tries to get a refresh token respecting retry counter.
+   */
+  getAuthorizationHeader(): angular.IPromise<string> {
+    if (!this.isValid()) {
+      this.retry++;
+      if (this.retry > 3) {
+        const deferred = this.$q.defer();
+        deferred.reject('Retried the refresh flow but token is likely invalid or server is down');
+        return deferred.promise;
+      }
+      return this.refresh()
+        .then(() => this.getAuthorizationHeader());
+    }
+    const deferred = this.$q.defer();
+    deferred.resolve('Bearer ' + this.token['access_token']);
+    return deferred.promise;
+  }
+
+  isValid(): boolean {
+    return this.isLogged() && new Date().getTime() < this.expiration;
+  }
+
+  isLogged(): boolean {
+    return !!this.token;
+  }
+
+  private refresh() {
+    const start = new Date().getTime();
+    return this.$http.post(
+        'api/security/oauth2',
+        'refresh_token=' + encodeURIComponent(this.token['refresh_token']) + '&grant_type=refresh_token',
+        {headers: {'Content-Type': 'application/x-www-form-urlencoded'}})
+      .then((response) => this.onLoad(response, start));
+  }
+
+  private onLoad(response, start) {
+    this.retry = 0;
+    this.token = response.data;
+    this.expiration = start + (1000 * (this.token['expires_in'] || 3600))
+  }
+}
+
+/**
+ * Intended to be used if the GUI exposes a selector for the auth type.
+ * This selector will accept 'Basic' and 'OAuth2' values.
+ */
+class HeaderProviderSelector {
+  constructor(private oauth2: OAuth2HeaderProvider,
+              private basic: BasicHeaderProvider) {
+  }
+
+  select(type): AuthenticationHeaderProvider {
+    switch(type) {
+      case 'Basic':
+        return this.basic;
+      case 'OAuth2':
+      default:
+        return this.oauth2;
+    }
+  }
+}
+
+// register them all as angular services
+angular.module('tribe-services-header-providers', ['website-browser'])
+  .service('tribeOauth2HeaderProvider', ['$http',  '$q', OAuth2HeaderProvider])
+  .service('tribeBasicHeaderProvider', ['$q', BasicHeaderProvider])
+  .service('tribeHeaderProviderSelector', ['tribeOauth2HeaderProvider', 'tribeBasicHeaderProvider', HeaderProviderSelector]);

--- a/tribestream-api-registry-webapp/src/test/static/test_services_header_providers.ts
+++ b/tribestream-api-registry-webapp/src/test/static/test_services_header_providers.ts
@@ -1,0 +1,120 @@
+///<reference path="../../main/static/bower_components/DefinitelyTyped/mocha/mocha.d.ts"/>
+///<reference path="../../main/static/bower_components/DefinitelyTyped/chai/chai.d.ts"/>
+///<reference path="../../main/static/bower_components/DefinitelyTyped/angularjs/angular-mocks.d.ts"/>
+
+// to run using mocha web runner start tomee and gulp (if you work on it)
+// and run http://localhost:8080/registry/?test=true&grep=header%20providers
+describe('it tests the header providers', () => {
+  let $httpBackend, $rootScope;
+  let tribeOauth2HeaderProvider, tribeBasicHeaderProvider, tribeHeaderProviderSelector;
+  let expect = chai.expect;
+  let fail = chai.assert.fail;
+
+  beforeEach(module('tribe-services-header-providers'));
+  beforeEach(inject([
+      '$rootScope', '$httpBackend', 'tribeOauth2HeaderProvider', 'tribeBasicHeaderProvider', 'tribeHeaderProviderSelector',
+      (rootScope, backend, oauth2Service, basicService, selector) => {
+        $rootScope = rootScope;
+        $httpBackend = backend;
+        tribeOauth2HeaderProvider = oauth2Service;
+        tribeBasicHeaderProvider = basicService;
+        tribeHeaderProviderSelector = selector;
+      }]));
+
+  afterEach(() => {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('should be able to select Basic provider', () => expect(tribeHeaderProviderSelector.select('Basic')).to.equal(tribeBasicHeaderProvider));
+  it('should be able to select OAuth2 provider', () => expect(tribeHeaderProviderSelector.select('OAuth2')).to.equal(tribeOauth2HeaderProvider));
+
+  it('should not be valid at the beginning (Basic)', () => expect(tribeBasicHeaderProvider.isValid()).to.equal(false));
+  it('should not be logged at the beginning (Oauth2)', () => expect(tribeOauth2HeaderProvider.isLogged()).to.equal(false));
+
+  it('should get a Basic token on any login', done => {
+    tribeBasicHeaderProvider.login('testuser', 'testpwd')
+      .then(token => {
+        expect(tribeBasicHeaderProvider.isValid()).to.equal(true);
+        expect(token['token']).to.equal('Basic dGVzdHVzZXI6dGVzdHB3ZA=='); // not that important, just there as a hook
+        tribeBasicHeaderProvider.getAuthorizationHeader().then(header => {
+          expect(header).to.equal('Basic dGVzdHVzZXI6dGVzdHB3ZA==');
+
+          // reset
+          tribeBasicHeaderProvider.logout();
+          done();
+        });
+      });
+    $rootScope.$apply(); // basic will use a deferred, enforce it to be evaluated
+  });
+
+  it('should get a Oauth2 token on a valid login', done => {
+    $httpBackend.expectPOST('api/security/oauth2', 'username=valid&password=login&grant_type=password')
+      .respond(200, {access_token: 'access', refresh_token: 'refresh', expires_in: 3600});
+
+    tribeOauth2HeaderProvider.login('valid', 'login')
+      .then(() => {
+        expect(tribeOauth2HeaderProvider.isLogged()).to.equal(true);
+        expect(tribeOauth2HeaderProvider.isValid()).to.equal(true);
+        tribeOauth2HeaderProvider.getAuthorizationHeader().then(header => {
+          expect(header).to.equal('Bearer access');
+
+          // reset
+          tribeOauth2HeaderProvider.logout();
+          done();
+        });
+      });
+
+    $httpBackend.flush();
+  });
+
+  it('should refresh a token on expired ones', done => {
+    $httpBackend.expectPOST('api/security/oauth2', 'username=valid&password=login&grant_type=password')
+      .respond(200, {access_token: 'access', refresh_token: 'refresh', expires_in: -1});
+    $httpBackend.expectPOST('api/security/oauth2', 'refresh_token=refresh&grant_type=refresh_token')
+      .respond(200, {access_token: 'access2', refresh_token: 'refresh2', expires_in: 3600});
+
+    tribeOauth2HeaderProvider.login('valid', 'login')
+      .then(() => {
+        expect(tribeOauth2HeaderProvider.isLogged()).to.equal(true);
+        expect(tribeOauth2HeaderProvider.isValid()).to.equal(false);
+
+        // will trigger a refresh flow
+        tribeOauth2HeaderProvider.getAuthorizationHeader().then(header => {
+          expect(header).to.equal('Bearer access2');
+
+          // reset
+          tribeOauth2HeaderProvider.logout();
+          done();
+        });
+      });
+
+    $httpBackend.flush();
+  });
+
+  it('should fail if refresh is not possible', done => {
+    $httpBackend.expectPOST('api/security/oauth2', 'username=valid&password=login&grant_type=password')
+      .respond(200, {access_token: 'access', refresh_token: 'refresh', expires_in: -1});
+    $httpBackend.expectPOST('api/security/oauth2', 'refresh_token=refresh&grant_type=refresh_token')
+      .respond(400, {message: 'simulating an error'});
+
+    tribeOauth2HeaderProvider.login('valid', 'login')
+      .then(() => {
+        expect(tribeOauth2HeaderProvider.isLogged()).to.equal(true);
+        expect(tribeOauth2HeaderProvider.isValid()).to.equal(false);
+
+        // will trigger a refresh flow
+        tribeOauth2HeaderProvider.getAuthorizationHeader().then(
+          header => fail(header, '', 'An invalid refresh token flow should lead to an error'),
+          error => {
+            expect(error.data.message).to.equal('simulating an error');
+
+            // reset
+            tribeOauth2HeaderProvider.logout();
+            done();
+          });
+      });
+
+    $httpBackend.flush();
+  });
+});


### PR DESCRIPTION
Small basic code to handle oauth2 and basic Authorization header

Part of the PR:
- abstraction for Basic and OAuth2 authentication
- OAuth2/Basic logic to get the Authorization header
- basic testiing of these implementation with http mocks (see TODO)

TODO:
- wire the selector to the GUI/authenticator
- move tests to tests with backend once we have the backend and the testing PR merged
