### PR TITLE
REG-256 - Unleash the history button

### DIFF
--- a/tribestream-api-registry-webapp/src/main/static/assets/templates/app_endpoints_details.jade
+++ b/tribestream-api-registry-webapp/src/main/static/assets/templates/app_endpoints_details.jade
@@ -18,5 +18,5 @@ div
         div(data-app-endpoints-details-history)
         div
           button.orange(x-ng-click="save()") Save
-          //button.orange(x-ng-click="showHistory()") Show History
+          button.orange(x-ng-click="showHistory()") Show History
     div(data-app-footer)


### PR DESCRIPTION
Unleashes the "History" button at the bottom of the endpoint details page.

This needs some serious styling though. 
Additionally I am not sure in what way to present the history table: 
- Open a Dialog
- Switch screens

Atm it's simply an ugly table at the bottom of the page.

But maybe sth ugly helps drive the decision.

Additionally pagination buttons are still missing, but these should be fairly simple and only follow the links.
But the visual pattern for pagination is missing I guess.
