### PR TITLE
Add support for property tribe.registry.base. Hotfix to circumvent pr…

### DIFF
--- a/tribestream-api-registry-webapp/pom.xml
+++ b/tribestream-api-registry-webapp/pom.xml
@@ -303,7 +303,14 @@
             <db>new://Resource?type=DataSource</db>
             <db.JdbcUrl>jdbc:h2:mem:registry</db.JdbcUrl>
             <db.JdbcDriver>org.h2.Driver</db.JdbcDriver>
-            <registry.oauth2.authorizationServerUrl>${registry.oauth2.gatewayUrl}</registry.oauth2.authorizationServerUrl>
+            <registry.oauth2.authorizationServerUrl>${registry.oauth2.authorizationServerUrl}</registry.oauth2.authorizationServerUrl>
+            <registry.oauth2.clientId>${registry.oauth2.clientId}</registry.oauth2.clientId>
+            <registry.oauth2.clientSecret>${registry.oauth2.clientSecret}</registry.oauth2.clientSecret>
+            <registry.oauth2.tlsProtocol>${registry.oauth2.tlsProtocol}</registry.oauth2.tlsProtocol>
+            <registry.oauth2.tlsProvider>${registry.oauth2.tlsProvider}</registry.oauth2.tlsProvider>
+            <registry.oauth2.trustStore>${registry.oauth2.tlsProvider}</registry.oauth2.trustStore>
+            <registry.oauth2.trustStoreType>${registry.oauth2.trustStoreType}</registry.oauth2.trustStoreType>
+            <tribe.registry.base>${tribe.registry.base}</tribe.registry.base>
           </containerProperties>
           <users>
             <admin>admin</admin>
@@ -351,6 +358,7 @@
             <registry.oauth2.tlsProvider>${registry.oauth2.tlsProvider}</registry.oauth2.tlsProvider>
             <registry.oauth2.trustStore>${registry.oauth2.tlsProvider}</registry.oauth2.trustStore>
             <registry.oauth2.trustStoreType>${registry.oauth2.trustStoreType}</registry.oauth2.trustStoreType>
+            <tribe.registry.base>${tribe.registry.base}</tribe.registry.base>
           </systemVariables>
         </configuration>
       </plugin>

--- a/tribestream-api-registry-webapp/src/main/java/org/tomitribe/tribestream/registryng/resources/HistoryResource.java
+++ b/tribestream-api-registry-webapp/src/main/java/org/tomitribe/tribestream/registryng/resources/HistoryResource.java
@@ -20,6 +20,7 @@ package org.tomitribe.tribestream.registryng.resources;
 
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.deltaspike.core.api.config.ConfigProperty;
 import org.tomitribe.tribestream.registryng.domain.EndpointWrapper;
 import org.tomitribe.tribestream.registryng.domain.HistoryItem;
 import org.tomitribe.tribestream.registryng.entities.Endpoint;
@@ -58,6 +59,11 @@ public class HistoryResource {
     private final OpenAPIDocumentSerializer documentSerializer;
     private final ApplicationProcessor processor;
 
+    @Inject
+    @ConfigProperty(name = "tribe.registry.base")
+    private String baseUrl;
+
+
     @GET
     @Path("/{applicationId}")
     public Response getApplicationHistory(
@@ -75,7 +81,7 @@ public class HistoryResource {
                 .map(HistoryItem::new)
                 .collect(toList());
 
-        UriBuilder historyApplicationBaseUriBuilder = uriInfo.getBaseUriBuilder()
+        UriBuilder historyApplicationBaseUriBuilder = getBase(uriInfo)
                 .path("history/application/{applicationId}")
                 .resolveTemplate("applicationId", applicationId);
 
@@ -92,8 +98,12 @@ public class HistoryResource {
                 .build();
     }
 
+    private UriBuilder getBase(UriInfo uriInfo) {
+        return baseUrl == null ? uriInfo.getBaseUriBuilder() : UriBuilder.fromUri(baseUrl);
+    }
+
     private Link buildCurrentApplicationLink(final UriInfo uriInfo, final String applicationId) {
-        return Link.fromUriBuilder(uriInfo.getBaseUriBuilder()
+        return Link.fromUriBuilder(getBase(uriInfo)
                 .path("application/{applicationId}")
                 .resolveTemplate("applicationId", applicationId))
                 .rel("application")
@@ -101,7 +111,7 @@ public class HistoryResource {
     }
 
     private Link buildCurrentEndpointLink(final UriInfo uriInfo, final String applicationId, final String endpointId) {
-        return Link.fromUriBuilder(uriInfo.getBaseUriBuilder()
+        return Link.fromUriBuilder(getBase(uriInfo)
                 .path("application/{applicationId}/endpoint/{endpointId}")
                 .resolveTemplate("applicationId", applicationId)
                 .resolveTemplate("endpointId", endpointId))


### PR DESCRIPTION
…oxy configuration issues.

Adds support for a config property `tribe.registry.base` to resolve issues with links and a bad proxy setup, so that the returned links are relative to the host base (e.g. ec2-123.123.aws.amazon.com/registry), instead of to the requested base uri (registry.tomitribe.ninja/blabla). 
