### PR TITLE
Limit ElasticSearch search for search page to configured index instea…

### DIFF
--- a/tribestream-api-registry-webapp/src/main/java/org/tomitribe/tribestream/registryng/elasticsearch/ElasticsearchClient.java
+++ b/tribestream-api-registry-webapp/src/main/java/org/tomitribe/tribestream/registryng/elasticsearch/ElasticsearchClient.java
@@ -136,7 +136,8 @@ public class ElasticsearchClient {
 
     public JsonObject search(final JsonObject query, final long from, final long size) {
         try {
-            WebTarget target = client.target(base).path("_search");
+            WebTarget target = client.target(base).path("{index}/_search")
+                    .resolveTemplate("index", index);
             if (from >= 0) {
                 target = target.queryParam("from", from);
             }


### PR DESCRIPTION
…d of searching over all indices.

Without this PR the search page will fail to load if ElasticSearch contains other indices like for example `.kibana`.
