### PR TITLE
REG-92 Make tables have a light line to separate the rows

### DIFF
--- a/tribestream-api-registry-webapp/src/main/static/assets/styles/_app_endpoints_details_common.sass
+++ b/tribestream-api-registry-webapp/src/main/static/assets/styles/_app_endpoints_details_common.sass
@@ -5,7 +5,7 @@ $app-max-width: 100%
 
 @mixin table-row-highlight($color)
   tr
-    border-top: dashed $color 1px
+    border-top: solid $color 1px
     &:first-of-type
       border-color: transparent
     > td

--- a/tribestream-api-registry-webapp/src/main/static/assets/styles/_common_table.sass
+++ b/tribestream-api-registry-webapp/src/main/static/assets/styles/_common_table.sass
@@ -26,6 +26,6 @@
       padding-top: 5px
     tr
       $color: #f2f4f5
-      border-top: dashed $color 1px
+      border-top: solid $color 1px
       &:last-of-type
-        border-bottom: dashed $color 1px
+        border-bottom: solid $color 1px


### PR DESCRIPTION
Registry UX - make sure tables have a light line to separate the rows so it is more readable