### PR TITLE
REG-408 Empty "See also" fields are saved on the endpoint details page

### DIFF
--- a/tribestream-api-registry-webapp/src/main/static/assets/scripts/endpoints_details.ts
+++ b/tribestream-api-registry-webapp/src/main/static/assets/scripts/endpoints_details.ts
@@ -610,6 +610,10 @@ angular.module('tribe-endpoints-details', [
             if (!!$scope.endpoint.endpointProtocol) {
               $scope.endpoint.operation.schemes = [$scope.endpoint.endpointProtocol];
             }
+            if(!!$scope.endpoint.operation['x-tribestream-api-registry'] && !!$scope.endpoint.operation['x-tribestream-api-registry'].sees) {
+              $scope.endpoint.operation['x-tribestream-api-registry'].sees =
+                  $scope.endpoint.operation['x-tribestream-api-registry'].sees.filter(v=>!!v.href);
+            }
             if ($scope.endpointLink) {
               srv.saveEndpoint($scope.endpointLink, {
                 // Cannot simply send the endpoint object because it's polluted with errors and expectedValues


### PR DESCRIPTION
REG-408 Empty "See also" fields are saved on the endpoint details page